### PR TITLE
fix: always use nanoid for uniqueness and fix nanoid import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ import {context, GitHub} from "@actions/github"
 import chalk from "chalk"
 import getBooleanActionInput from "get-boolean-action-input"
 import isGitRepoDirty from "is-git-repo-dirty"
-import nanoid from "nanoid"
+import { nanoid } from "nanoid"
 import resolveAny from "resolve-any"
 import zahl from "zahl"
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,11 @@ import {context, GitHub} from "@actions/github"
 import chalk from "chalk"
 import getBooleanActionInput from "get-boolean-action-input"
 import isGitRepoDirty from "is-git-repo-dirty"
-import { nanoid } from "nanoid"
+import { customAlphabet } from "nanoid"
 import resolveAny from "resolve-any"
 import zahl from "zahl"
+
+const nanoid = customAlphabet("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 8)
 
 /**
  * @typedef {Object} Options
@@ -96,7 +98,7 @@ export default class CommitManager {
     if (this.branch) {
       return
     }
-    const branchId = nanoid("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 8)
+    const branchId = nanoid()
     const branchPrefix = await resolveAny(this.options.branchPrefix, this)
     this.branch = `${branchPrefix}${branchId}`
     await exec("git", ["config", "user.email", "action@github.com"])

--- a/src/index.js
+++ b/src/index.js
@@ -96,12 +96,7 @@ export default class CommitManager {
     if (this.branch) {
       return
     }
-    let branchId
-    if (context.sha) {
-      branchId = context.sha.slice(0, 8)
-    } else {
-      branchId = nanoid("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 8)
-    }
+    const branchId = nanoid("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", 8)
     const branchPrefix = await resolveAny(this.options.branchPrefix, this)
     this.branch = `${branchPrefix}${branchId}`
     await exec("git", ["config", "user.email", "action@github.com"])


### PR DESCRIPTION
The `context.sha` approach does not work for uniqueness if you manually dispatch the action. In [action-sync-node-meta](https://github.com/Jaid/action-sync-node-meta) it makes sense to setup a scheduled workflow that regularly checks the metadata. You might want to change the metadata but not push any code.